### PR TITLE
Django 1.6 compatibility

### DIFF
--- a/searchableselect/views.py
+++ b/searchableselect/views.py
@@ -16,7 +16,25 @@ except ImportError:
     get_model = apps.get_model
 
 from django.utils.encoding import smart_str
-from django.http import JsonResponse
+from django.http import HttpResponse
+
+try:
+    from django.http import JsonResponse
+except ImportError as e:
+    # Django < 1.7
+    from django.utils import simplejson
+    class JsonResponse(HttpResponse):
+        """
+            JSON response
+        """
+        def __init__(self, content, mimetype='application/json', status=None, content_type=None):
+            super(JsonResponse, self).__init__(
+                content=simplejson.dumps(content),
+                mimetype=mimetype,
+                status=status,
+                content_type=content_type,
+    )
+
 from django.contrib.admin.views.decorators import staff_member_required
 
 

--- a/searchableselect/views.py
+++ b/searchableselect/views.py
@@ -4,7 +4,7 @@ try:
 
     # Django 1.6.*
     import django
-    if django.VERSION[0] == 1 and django.VERSION == 6:
+    if django.VERSION[0] == 1 and django.VERSION[1] == 6:
         def get_model_wrapper(model):
             get_model(*model.split('.'))
 

--- a/searchableselect/views.py
+++ b/searchableselect/views.py
@@ -1,6 +1,15 @@
 try:
     # Django <=1.9
     from django.db.models.loading import get_model
+
+    # Django 1.6.*
+    import django
+    if django.VERSION[0] == 1 and django.VERSION == 6:
+        def get_model_wrapper(model):
+            get_model(*model.split('.'))
+
+        get_model = get_model_wrapper
+
 except ImportError:
     # Django 1.10+
     from django.apps import apps

--- a/searchableselect/widgets.py
+++ b/searchableselect/widgets.py
@@ -3,6 +3,15 @@ from django import forms
 try:
     # Django <=1.9
     from django.db.models.loading import get_model
+
+    # Django 1.6.*
+    import django
+    if django.VERSION[0] == 1 and django.VERSION == 6:
+        def get_model_wrapper(model):
+            get_model(*model.split('.'))
+
+        get_model = get_model_wrapper
+
 except ImportError:
     # Django 1.10+
     from django.apps import apps

--- a/searchableselect/widgets.py
+++ b/searchableselect/widgets.py
@@ -6,7 +6,7 @@ try:
 
     # Django 1.6.*
     import django
-    if django.VERSION[0] == 1 and django.VERSION == 6:
+    if django.VERSION[0] == 1 and django.VERSION[1] == 6:
         def get_model_wrapper(model):
             get_model(*model.split('.'))
 


### PR DESCRIPTION
In my old project on Django 1.6.5 very needed your useful widget and I make compatibility.
Django 1.6 not have JsonResponse and get_model taken next 2 arguments: app and model(may be this true for lower versions of Django, no tested). I think this patch does help other peoples with legacy projects.