### PR TITLE
Fix Double trigger

### DIFF
--- a/searchableselect/static/searchableselect/main.js
+++ b/searchableselect/static/searchableselect/main.js
@@ -121,7 +121,7 @@
                         }, 0);
                     },
                     onEnter: function () {
-                        $(this).parent().find('.tt-dataset .tt-suggestion.tt-selectable').first().trigger('click');
+                        $(this).parent().find('.tt-open .tt-dataset .tt-suggestion.tt-selectable').first().trigger('click');
                     }
                 });
             })($select);


### PR DESCRIPTION
Prevent Double click trigger that override selecting when pressing Enter after selecting a chip

To reproduce : 
- Start tiping something
- Select a chip that is not the first one
- Press Enter

Selection will be overriten before form validation and will select the first chip in current search query