### PR TITLE
Django 2.x url import error

### DIFF
--- a/searchableselect/urls.py
+++ b/searchableselect/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except ImportError:
+    # Django > 2.x
+    from django.urls import re_path as url
 try:
     # Django <=1.9
     from django.conf.urls import patterns


### PR DESCRIPTION
Fixed "ImportError: cannot import name 'url' from 'django.conf.urls'" error which was occurring when using  with Django 2.x